### PR TITLE
Base を継承しているクラスが module 内にあったとき、生成されるシャードクラスもその module で作られるようにした

### DIFF
--- a/lib/sengiri/model/base.rb
+++ b/lib/sengiri/model/base.rb
@@ -40,7 +40,9 @@ module Sengiri
           raise "Databases are not found" if shard_names.blank?
           shard_names.each do |s|
             klass = Class.new(self)
-            Object.const_set self.name + s, klass
+            module_name = self.name.deconstantize
+            module_name = "Object" if module_name.blank?
+            module_name.constantize.const_set self.name.demodulize + s, klass
             klass.instance_variable_set :@shard_name, s
             klass.instance_variable_set :@dbconfs,    dbconfs
             klass.instance_variable_set :@sharding_group_name, name

--- a/spec/lib/sengiri/model/base_spec.rb
+++ b/spec/lib/sengiri/model/base_spec.rb
@@ -109,4 +109,38 @@ describe SengiriModel do
       }.to raise_error
     end
   end
+
+  context 'is included in module' do
+    let(:sengiri_model) {
+      module SengiriModule
+        class SengiriModel < Sengiri::Model::Base
+          sharding_group 'sengiri', confs: {
+              'sengiri_shard_1_rails_env'=> {
+                adapter: "sqlite3",
+                database: "spec/db/sengiri_shard_1.sqlite3",
+                pool: 5,
+                timeout: 5000,
+              },
+              'sengiri_shard_second_rails_env'=> {
+                adapter: "sqlite3",
+                database: "spec/db/sengiri_shard_2.sqlite3",
+                pool: 5,
+                timeout: 5000,
+              },
+            }
+        end
+      end
+    }
+    it 'should be normal' do
+      expect { sengiri_model }.not_to raise_error
+    end
+    context 'when sengiri_model is evaluated' do
+      before do
+        sengiri_model
+      end
+      it 'should create a new shard class in the module' do
+        expect { SengiriModule::SengiriModel1 }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
```
module Foo
  class Bar < Sengiri::Model::Base
    sharding_group :baz
  end
end
```

のようなものを作ると例外がでる修正
