### PR TITLE
establish_connection するのは各 DB 設定で一回限りにし、コネクションを共用するようにした

### DIFF
--- a/spec/lib/sengiri/model/base_spec.rb
+++ b/spec/lib/sengiri/model/base_spec.rb
@@ -143,4 +143,33 @@ describe SengiriModel do
       end
     end
   end
+
+  context 'when the other model with the same DB confs exists' do
+    before do
+      class SengiriModelWithSameDBConfs < Sengiri::Model::Base
+        sharding_group 'sengiri', confs: {
+            'sengiri_shard_1_rails_env'=> {
+              adapter: "sqlite3",
+              database: "spec/db/sengiri_shard_1.sqlite3",
+              pool: 5,
+              timeout: 5000,
+            },
+            'sengiri_shard_second_rails_env'=> {
+              adapter: "sqlite3",
+              database: "spec/db/sengiri_shard_2.sqlite3",
+              pool: 5,
+              timeout: 5000,
+            },
+          }
+      end
+    end
+
+    it 'should use the same connections' do
+      aggregate_failures 'testing connections' do
+        expect(SengiriModel.connection).to be SengiriModelWithSameDBConfs.connection
+        expect(SengiriModel.shard('1').connection).to be SengiriModelWithSameDBConfs.shard('1').connection
+        expect(SengiriModel.shard('second').connection).to be SengiriModelWithSameDBConfs.shard('second').connection
+      end
+    end
+  end
 end


### PR DESCRIPTION
この PR をマージすると、 https://github.com/mewlist/sengiri/issues/18 が解決します。

問題の詳細ですが、たとえば DB に MySql を使い、かつ `1` でシャーディングされている `Foo`, `Bar` というモデルがあったとして、`rails console` で以下のコードを実行すると、

``` ruby
Foo1.transaction do
 Foo1.create!
 Bar1.create!
 raise
end
```

`Bar1.create!` がロールバックされずインサートされてしまいます。このときの MySql のログは以下のようになっていて、

``` sh
160317 17:40:03      364 Connect    root@localhost on XXX_development_XXX_shard_1
          364 Query    SET NAMES utf8,  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483, @@SESSION.sql_mode = 'STRICT_ALL_TABLES'
          364 Query    BEGIN
          364 Query    SHOW FULL FIELDS FROM `foos`
          364 Query    SHOW TABLES
          364 Query    SHOW CREATE TABLE `foos`
160317 17:40:04      364 Query    INSERT INTO `foos` (`created_at`, `updated_at`) VALUES ('2016-03-17 08:40:04', '2016-03-17 08:40:04')
          366 Connect    root@localhost on XXX_development_XXX_shard_1
          366 Query    SET NAMES utf8,  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483, @@SESSION.sql_mode = 'STRICT_ALL_TABLES'
          366 Query    SHOW FULL FIELDS FROM `bars`
          366 Query    SHOW TABLES
          366 Query    SHOW CREATE TABLE `bars`
          366 Query    BEGIN
          366 Query    INSERT INTO `bars` (`created_at`, `updated_at`) VALUES ('2016-03-17 08:40:04', '2016-03-17 08:40:04')
          366 Query    COMMIT
          364 Query    ROLLBACK
```

`Foo1`, `Bar1` のクエリが別々の Thread ID を持つ MySql コネクションを使って実行されてしまっているため、コード上のトランザクションが正しく共有されず、一部のクエリがコミットされてしまっているものと思われます。

これは issue にもありましたが、 `Foo1`, `Bar1` のクラスが自動生成される都度 `establish_connection` を実行し、`Foo1`, `Bar1` が別々のコネクション（正確には `Mysql2Adapter` のインスタンス）を持ってしまっているのが原因なので、 `establish_connection` するクラスは各 DB 設定で一つのみにし、`establish_connection` したクラスのコネクションを各シャーディングクラスが共用できるようにして問題を解決しました。
