### PR TITLE
shading 用の db:drop タスクが db:check_protected_environments のチェックに引っかかって、正常に行われないのを直した

### DIFF
--- a/lib/sengiri/railties/sharding.rake
+++ b/lib/sengiri/railties/sharding.rake
@@ -66,7 +66,7 @@ namespace :sengiri do
 
       desc "drop on '#{shard}' databases"
       task :drop => [:environment, :load_config] do
-        execute_with_dbtask_env.call :drop
+        execute_with_dbtask_env.call 'drop:_unsafe' # Avoid db:check_protected_environments.
       end
 
       desc "migrate on '#{shard}' databases"


### PR DESCRIPTION
Rails5 になってDB誤爆削除防止機能として `db:check_protected_environments` タスクが入ったらしいのですが、`sengiri` の `db:drop` を実行するとこのチェックに引っかかって、sharding された DB の削除が正常に行えなくなってしまっていました（sharding されている DB が2つあったとして、`db:drop` すると最初の DB しか削除されない。production 環境ではないのに）。

 `drop:_unsafe` を使ったら、 `db:check_protected_environments` のチェックを回避し正常に全ての DB とドロップできたので、そのような変更を行いました。

なぜ protected_environments でないのにそのようなチェックに引っかかってタスクが実行できないのか深く追ってはいないので、もっと適切な直し方はあるかもしれません（教えていただければそのように直します）。

該当のタスクのコード:
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railties/databases.rake#L36-L43