### PR TITLE
Expand broadcast features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg/
 *.swp
 *.gem
 .idea
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     sengiri (0.1.0)
+      parallel
       rails (~> 5.1)
 
 GEM
@@ -67,6 +68,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    parallel (1.12.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/lib/sengiri.rb
+++ b/lib/sengiri.rb
@@ -1,18 +1,7 @@
+require 'parallel'
+require 'sengiri/broadcast_proxy'
+require 'sengiri/model/base'
+require 'sengiri/railtie' if defined? Rails
+
 module Sengiri
-  require "sengiri/model/base"
-  require "sengiri/railtie" if defined? Rails
-end
-
-
-module ActiveRecord
-  class Relation
-    def broadcast
-      records = []
-      klass.shard_names.each do |shard_name|
-        records += shard(shard_name).find_by_sql(to_sql)
-      end
-      @records = records
-      @records
-    end
-  end
 end

--- a/lib/sengiri/broadcast_proxy.rb
+++ b/lib/sengiri/broadcast_proxy.rb
@@ -1,0 +1,56 @@
+module Sengiri
+  class BroadcastProxy
+    include Enumerable
+
+    def initialize(shard_classes, scope: nil, max_threads: )
+      @shard_classes = shard_classes
+      @scope = scope
+      @max_threads = max_threads
+    end
+
+    def each(&block)
+      if block_given?
+        to_a.each(&block)
+      else
+        to_a.each
+      end
+    end
+
+    def to_a
+      parallel(&:to_a).flatten
+    end
+
+    def find_by(query)
+      records = parallel { |relation|
+        relation.find_by(query)
+      }
+      records.detect { |record| record }
+    end
+
+    def find_by!(query)
+      result = find_by(query)
+      if result.nil?
+        raise ActiveRecord::RecordNotFound.new("Couldn't find #{query} with an out of range value")
+      end
+      result
+    end
+
+    private
+
+    def parallel
+      Parallel.map(@shard_classes, in_threads: @max_threads){ |shard_class|
+        shard_class.connection_pool.with_connection do
+          yield scoped(shard_class)
+        end
+      }
+    end
+
+    def scoped(shard_class)
+      if @scope
+        shard_class.merge(@scope)
+      else
+        shard_class
+      end
+    end
+  end
+end

--- a/lib/sengiri/model/base.rb
+++ b/lib/sengiri/model/base.rb
@@ -123,6 +123,10 @@ module Sengiri
           end
         end
 
+        def broadcast(max_threads=5)
+          Sengiri::BroadcastProxy.new(shard_classes, scope: current_scope, max_threads: max_threads)
+        end
+
         def env
           ENV["SENGIRI_ENV"] ||= ENV["RAILS_ENV"] || 'development'
         end

--- a/sengiri.gemspec
+++ b/sengiri.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 5.1"
+  s.add_runtime_dependency 'rails', '~> 5.1'
+  s.add_runtime_dependency 'parallel'
 
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rspec"
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry-byebug'
 end

--- a/spec/lib/sengiri/broadcast_proxy_spec.rb
+++ b/spec/lib/sengiri/broadcast_proxy_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Sengiri::BroadcastProxy do
+  before do
+    shard1.create!(name: 'hoge')
+    shard1.create!(name: 'fuga')
+    shard2.create!(name: 'moge')
+    shard2.create!(name: 'hugo')
+  end
+
+  describe '#find_by' do
+    subject do
+      SengiriModel.broadcast.find_by(query)
+    end
+
+    let(:query) do
+      { name: 'moge' }
+    end
+
+    it 'should find just one of all shards in' do
+      expect(subject.name).to eq(query[:name])
+    end
+  end
+
+  describe '#find_by!' do
+    subject do
+      SengiriModel.broadcast.find_by!(query)
+    end
+
+    context 'found it' do
+      let(:query) do
+        { name: 'hoge' }
+      end
+
+      it 'should find just one of all shards in' do
+        expect(subject.name).to eq(query[:name])
+      end
+    end
+
+    context 'record not found' do
+      let(:query) do
+        { name: '@@@@@@@' }
+      end
+
+      it 'should raise error' do
+        expect {
+          subject
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe 'inherit current scope' do
+    subject do
+      SengiriModel.where(name: ['hoge', 'fuga']).broadcast
+    end
+
+    it 'should merge query' do
+      expect(subject.find_by(name: 'hoge')).to be_present
+      expect(subject.find_by(name: 'hugo')).to be_nil
+    end
+  end
+end

--- a/spec/lib/sengiri/model/base_spec.rb
+++ b/spec/lib/sengiri/model/base_spec.rb
@@ -1,43 +1,5 @@
 require 'spec_helper'
 
-ENV['SENGIRI_ENV'] = 'rails_env'
-
-class SengiriModel < Sengiri::Model::Base
-  sharding_group 'sengiri', confs: {
-      'sengiri_shard_1_rails_env'=> {
-        adapter: "sqlite3",
-        database: "spec/db/sengiri_shard_1.sqlite3",
-        pool: 5,
-        timeout: 5000,
-      },
-      'sengiri_shard_second_rails_env'=> {
-        adapter: "sqlite3",
-        database: "spec/db/sengiri_shard_2.sqlite3",
-        pool: 5,
-        timeout: 5000,
-      },
-    }
-end
-
-class SengiriModelWithSuffix < Sengiri::Model::Base
-  sharding_group 'sengiri', {
-    confs: {
-      'sengiri_shard_1_rails_env_suffix'=> {
-        adapter: "sqlite3",
-        database: "spec/db/sengiri_shard_secondary_1.sqlite3",
-        pool: 5,
-        timeout: 5000,
-      },
-      'sengiri_shard_second_rails_env_suffix'=> {
-        adapter: "sqlite3",
-        database: "spec/db/sengiri_shard_secondary_2.sqlite3",
-        pool: 5,
-        timeout: 5000,
-      },
-    },
-    suffix: 'suffix' }
-end
-
 describe SengiriModel do
   # clear db
   before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,20 +6,8 @@ require File.expand_path('../../lib/sengiri/model/base', __FILE__)
 require "sqlite3"
 require 'pry-byebug'
 
-def setup_test_database(path)
-  # Open a database
-  db = SQLite3::Database.new path
+Dir[File.expand_path("../support/**/*.rb", __FILE__)].each { |f| require f }
 
-  # Create a database
-  rows = db.execute <<-SQL
-    drop table if exists sengiri_models;
-  SQL
-  rows = db.execute <<-SQL
-    create table sengiri_models ( id int PRIMARY KEY, name varchar(30));
-  SQL
+RSpec.configure do |c|
+  c.include Helpers
 end
-
-setup_test_database "spec/db/sengiri_shard_1.sqlite3"
-setup_test_database "spec/db/sengiri_shard_2.sqlite3"
-setup_test_database "spec/db/sengiri_shard_secondary_1.sqlite3"
-setup_test_database "spec/db/sengiri_shard_secondary_2.sqlite3"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,9 @@
+module Helpers
+  def shard1
+    SengiriModel.shard(1)
+  end
+
+  def shard2
+    SengiriModel.shard('second')
+  end
+end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,0 +1,55 @@
+def setup_test_database(path)
+  # Open a database
+  db = SQLite3::Database.new path
+
+  # Create a database
+  rows = db.execute <<-SQL
+    drop table if exists sengiri_models;
+  SQL
+  rows = db.execute <<-SQL
+    create table sengiri_models ( id int PRIMARY KEY, name varchar(30));
+  SQL
+end
+
+setup_test_database "spec/db/sengiri_shard_1.sqlite3"
+setup_test_database "spec/db/sengiri_shard_2.sqlite3"
+setup_test_database "spec/db/sengiri_shard_secondary_1.sqlite3"
+setup_test_database "spec/db/sengiri_shard_secondary_2.sqlite3"
+
+ENV['SENGIRI_ENV'] = 'rails_env'
+
+class SengiriModel < Sengiri::Model::Base
+  sharding_group 'sengiri', confs: {
+    'sengiri_shard_1_rails_env'=> {
+      adapter: "sqlite3",
+      database: "spec/db/sengiri_shard_1.sqlite3",
+      pool: 5,
+      timeout: 5000,
+    },
+    'sengiri_shard_second_rails_env'=> {
+      adapter: "sqlite3",
+      database: "spec/db/sengiri_shard_2.sqlite3",
+      pool: 5,
+      timeout: 5000,
+    },
+  }
+end
+
+class SengiriModelWithSuffix < Sengiri::Model::Base
+  sharding_group 'sengiri', {
+    confs: {
+      'sengiri_shard_1_rails_env_suffix'=> {
+        adapter: "sqlite3",
+        database: "spec/db/sengiri_shard_secondary_1.sqlite3",
+        pool: 5,
+        timeout: 5000,
+      },
+      'sengiri_shard_second_rails_env_suffix'=> {
+        adapter: "sqlite3",
+        database: "spec/db/sengiri_shard_secondary_2.sqlite3",
+        pool: 5,
+        timeout: 5000,
+      },
+    },
+    suffix: 'suffix' }
+end


### PR DESCRIPTION
hello
This PR is implemented `Sengiri::BroadcastProxy`.

Please refer to the following usage!

```ruby
SengiriModel.broadcast.find_by(name: 'hoge')
SengiriModel.broadcast.find_by!(name: 'hoge')

SengiriModel.broadcast.each do |record|
  # ..
end

SengiriModel.broadcast.map(&:id)
```

## Concurrency

`BroadcastProxy` depends on `parallel` gem, so it uses thread pool and runs in parallel for each sharding DBs.
