### PR TITLE
Update Sengiri::Model::Base : raise error when no env Rails database

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Flexible sharding access for Ruby on Rails with ActiveRecord
 
 ## Sharding migration
 
+Move your migration file to sengiri db dir
+
+```bash
+    mkdir -p db/sengiri/mygroup
+    mv db/migration/xxxx_create_user.rb db/sengiri/mygroup
+```
+
 ActiveRecord task is available on every shard.
 
 ```ruby


### PR DESCRIPTION
rails example

```
RuntimeError (Not found database settings with env. )
You need specify database names with env ( e.g mygroup_shard_first_development , mygroup_shard_second_development , mygroup_shard_third_development )"
Or set empty value on ENV ( e.g SENGIRI_ENV= rails server )
```