### PR TITLE
Fix a bug that connections could not be divided each classes

### DIFF
--- a/lib/sengiri/model/base.rb
+++ b/lib/sengiri/model/base.rb
@@ -60,11 +60,11 @@ module Sengiri
         end
 
         def connection_specification_name
-          "#{@sharding_group_name}_shard_#{@shard_name}"
+          "#{@sharding_group_name}_shard_#{@shard_name}#{@sharding_database_suffix}"
         end
 
         def dbconf
-          dbconfs["#{connection_specification_name}_#{env}#{@sharding_database_suffix}"]
+          dbconfs["#{@sharding_group_name}_shard_#{@shard_name}_#{env}#{@sharding_database_suffix}"]
         end
 
         def dbconfs

--- a/spec/lib/sengiri/model/base_spec.rb
+++ b/spec/lib/sengiri/model/base_spec.rb
@@ -25,7 +25,7 @@ describe SengiriModel do
 
   end
 
-  context 'Sparated database access' do
+  context 'separated database access' do
     let(:first)  { SengiriModel.shard(1) }
     let(:second) { SengiriModel.shard('second') }
 
@@ -133,6 +133,12 @@ describe SengiriModel do
         expect(SengiriModel.shard('1').connection).to be SengiriModelWithSameDBConfs.shard('1').connection
         expect(SengiriModel.shard('second').connection).to be SengiriModelWithSameDBConfs.shard('second').connection
       end
+    end
+  end
+
+  context 'when inheriting' do
+    it 'should be held individually connection' do
+      expect(SengiriModel.connection).to_not be(SengiriModelSubclass.connection)
     end
   end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -53,3 +53,22 @@ class SengiriModelWithSuffix < Sengiri::Model::Base
     },
     suffix: 'suffix' }
 end
+
+class SengiriModelSubclass < SengiriModel
+  sharding_group 'sengiri', {
+    confs: {
+      'sengiri_shard_1_rails_env_suffix'=> {
+        adapter: "sqlite3",
+        database: "spec/db/sengiri_shard_secondary_1.sqlite3",
+        pool: 5,
+        timeout: 5000,
+      },
+      'sengiri_shard_second_rails_env_suffix'=> {
+        adapter: "sqlite3",
+        database: "spec/db/sengiri_shard_secondary_2.sqlite3",
+        pool: 5,
+        timeout: 5000,
+      },
+    },
+    suffix: 'suffix' }
+end


### PR DESCRIPTION
Even with the `:suffix` option, Sengiri::Model::Base.connection_specification_name is equal and connection is not splited.

Therefore, different classes will return the same connection.

```ruby
    # activerecord-5.2.0/lib/active_record/connection_handling.rb:117
    def retrieve_connection
      connection_handler.retrieve_connection(connection_specification_name)
    end
```

e.g.

```ruby
class User < Sengiri::Model::Base
  sharding_group :user_group
end

class ReadOnly::User < User
  sharding_group :user_group, suffix: 'readonly'
end
```

```
User.connection_specification_name #=> 'user_group_shard_1'
ReadOnly::User.connection_specification_name #=> 'user_group_shard_1'

ReadOnly::User.connection #=> => #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x00007fcf6007b3b8
User.connection #=> => #<ActiveRecord::ConnectionAdapters::Mysql2Adapter:0x00007fcf6007b3b8
```

## Fixes

If the connection destination is different, AR.connection_specification_name should return different values.
