### PR TITLE
Base act as first shard when shard is single

### DIFF
--- a/lib/sengiri/model/base.rb
+++ b/lib/sengiri/model/base.rb
@@ -33,7 +33,7 @@ module Sengiri
 
           raise "Databases are not found" if shard_names.blank?
 
-          @sharding_base = true
+          @sharding_base = true unless shard_names.length == 1
           @shard_name = shard_names.first
           establish_shard_connection
 


### PR DESCRIPTION
`with_lock` doesn't work well with instance that selected sharding_base model.

# Now
```
pry(main)> user.with_lock do
pry(main)*   p user.id
pry(main)* end
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 128944074001481729 LIMIT 1 FOR UPDATE
128944074001481729
=> 128944074001481729
```

# Expect
```
pry(main)> user.with_lock do
pry(main)*   p user.id
pry(main)* end
   (0.3ms)  BEGIN
  User Load (0.3ms)  SELECT  `users`.* FROM `users` WHERE `users`.`id` = 128944074001481729 LIMIT 1 FOR UPDATE
128944074001481729
   (0.1ms)  COMMIT
=> 128944074001481729
```