### PR TITLE
Support specified shard migration

### DIFF
--- a/lib/sengiri/model/base.rb
+++ b/lib/sengiri/model/base.rb
@@ -81,8 +81,12 @@ module Sengiri
 
         def shard_names
           @shard_names ||= dbconfs.map do |k,v|
-            k.gsub("#{@sharding_group_name}_shard_", '').gsub(/_#{env}#{@sharding_database_suffix}$/, '')
+            parse_shard_name(k, sharding_group_name: @sharding_group_name, env: env, sharding_database_suffix: @sharding_database_suffix)
           end
+        end
+
+        def parse_shard_name(spec_name, sharding_group_name:, env:, sharding_database_suffix: nil)
+          spec_name.gsub("#{sharding_group_name}_shard_", '').gsub(/_#{env}#{sharding_database_suffix}$/, '')
         end
 
         def establish_shard_connection

--- a/lib/sengiri/railties/sharding.rake
+++ b/lib/sengiri/railties/sharding.rake
@@ -19,11 +19,12 @@ namespace :sengiri do
     namespace :db do
 
       dbconfs = Rails.application.config.database_configuration.select {|name|
-        /^#{shard}/ =~ name
-      }.select {|name|
-        rails_env_list.select {|env|
-          /_#{env}$/ =~ name
-        }.present?
+        env = rails_env_list.detect {|env| /_#{env}$/.match?(name)}
+        shard_name = Sengiri::Model::Base.parse_shard_name(name, sharding_group_name: shard, env: env)
+
+        /^#{shard}/.match?(name) &&
+            env &&
+            (ENV['SHARD_NAME'].blank? || shard_name == ENV['SHARD_NAME'])
       }
       switch_db_config = lambda do
         puts "now on '#{shard}' shard."

--- a/lib/sengiri/railties/sharding.rake
+++ b/lib/sengiri/railties/sharding.rake
@@ -43,6 +43,7 @@ namespace :sengiri do
 
       execute_on_shards = lambda do |task|
         dbconfs.each do |k,dbconf|
+          puts "execute on shard #{k}."
           ActiveRecord::Base.establish_connection dbconf
           db_ns[task].execute
         end


### PR DESCRIPTION
If you specify a target shard, you can provide `SHARD_NAME` parameter.

`$ rake sengiri:mygroup:db:migrate SHARD_NAME=1`